### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/187/173/421187173.geojson
+++ b/data/421/187/173/421187173.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"BM",
     "wof:created":1459009504,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aaa6e7e0bcca5dd82dca2439ddcc57be",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421187173,
-    "wof:lastmodified":1566615562,
+    "wof:lastmodified":1582347108,
     "wof:name":"Chelston",
     "wof:parent_id":85669363,
     "wof:placetype":"locality",

--- a/data/421/200/623/421200623.geojson
+++ b/data/421/200/623/421200623.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"BM",
     "wof:created":1459010033,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"97590529ed179e346daa255127a1a299",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":421200623,
-    "wof:lastmodified":1566615562,
+    "wof:lastmodified":1582347108,
     "wof:name":"Hinson Hall",
     "wof:parent_id":85669381,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.