### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/171/923/421171923.geojson
+++ b/data/421/171/923/421171923.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0648\u0645\u0631\u0633\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0648\u0645\u0631\u0633\u062a"
+    ],
     "name:ceb_x_preferred":[
         "Somerset"
     ],
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421171923,
-    "wof:lastmodified":1566615562,
+    "wof:lastmodified":1690860232,
     "wof:name":"Somerset",
     "wof:parent_id":85669377,
     "wof:placetype":"locality",

--- a/data/856/693/45/85669345.geojson
+++ b/data/856/693/45/85669345.geojson
@@ -99,6 +99,9 @@
     "name:nob_x_preferred":[
         "Hamilton prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Hamilton Parish"
+    ],
     "name:pol_x_preferred":[
         "Parafia Hamilton"
     ],
@@ -116,6 +119,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bb9\u0bbe\u0bae\u0bbf\u0bb2\u0bcd\u0b9f\u0ba9\u0bcd \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0bb9\u0bbe\u0bae\u0bbf\u0bb2\u0bcd\u0b9f\u0ba9\u0bcd  \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c39\u0c3e\u0c2e\u0c3f\u0c32\u0c4d\u0c1f\u0c28\u0c4d \u0c2a\u0c3e\u0c30\u0c3f\u0c37\u0c4d"
@@ -262,7 +268,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501347,
+    "wof:lastmodified":1690860230,
     "wof:name":"City of Hamilton",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/55/85669355.geojson
+++ b/data/856/693/55/85669355.geojson
@@ -97,6 +97,9 @@
     "name:nob_x_preferred":[
         "Devonshire prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Devonshire Parish"
+    ],
     "name:pol_x_preferred":[
         "Parafia Devonshire"
     ],
@@ -263,7 +266,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501347,
+    "wof:lastmodified":1690860231,
     "wof:name":"Devonshire",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/63/85669363.geojson
+++ b/data/856/693/63/85669363.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0628\u0631\u0634\u064a\u0629 \u0628\u0627\u062c\u064a\u062a"
     ],
+    "name:bel_x_preferred":[
+        "\u041f\u0435\u0439\u0434\u0436\u044d\u0442"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09cd\u09af\u09be\u099c\u09c7\u099f \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
@@ -98,6 +101,9 @@
     "name:nob_x_preferred":[
         "Paget prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Paget Parish"
+    ],
     "name:nor_x_preferred":[
         "Paget prestegjeld"
     ],
@@ -148,6 +154,9 @@
     ],
     "name:zho_tw_x_preferred":[
         "\u4f69\u5409\u7279"
+    ],
+    "name:zho_x_preferred":[
+        "\u4f69\u5409\u7279\u5802\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"BMU",
@@ -268,7 +277,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501348,
+    "wof:lastmodified":1690860231,
     "wof:name":"Paget",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/67/85669367.geojson
+++ b/data/856/693/67/85669367.geojson
@@ -101,6 +101,9 @@
     "name:nob_x_preferred":[
         "Pembroke prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Pembroke Parish"
+    ],
     "name:pol_x_preferred":[
         "Parafia Pembroke"
     ],
@@ -267,7 +270,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501347,
+    "wof:lastmodified":1690860230,
     "wof:name":"Pembroke",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/73/85669373.geojson
+++ b/data/856/693/73/85669373.geojson
@@ -99,6 +99,9 @@
     "name:nob_x_preferred":[
         "St. George's prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "St. George's Parish"
+    ],
     "name:pol_x_preferred":[
         "Parafia St. George's"
     ],
@@ -262,7 +265,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501347,
+    "wof:lastmodified":1690860230,
     "wof:name":"Saint George's",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/77/85669377.geojson
+++ b/data/856/693/77/85669377.geojson
@@ -98,6 +98,9 @@
     "name:nob_x_preferred":[
         "Sandys prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Sandys Parish"
+    ],
     "name:pol_x_preferred":[
         "Parafia Sandys"
     ],
@@ -264,7 +267,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501348,
+    "wof:lastmodified":1690860231,
     "wof:name":"Sandys",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/81/85669381.geojson
+++ b/data/856/693/81/85669381.geojson
@@ -98,6 +98,9 @@
     "name:nob_x_preferred":[
         "Smith's prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Smith's Parish"
+    ],
     "name:pol_x_preferred":[
         "Parafia Smith's"
     ],
@@ -261,7 +264,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501347,
+    "wof:lastmodified":1690860230,
     "wof:name":"Smith's",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/85/85669385.geojson
+++ b/data/856/693/85/85669385.geojson
@@ -98,6 +98,9 @@
     "name:nob_x_preferred":[
         "Southampton prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Southampton Parish"
+    ],
     "name:pol_x_preferred":[
         "Southampton"
     ],
@@ -261,7 +264,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501348,
+    "wof:lastmodified":1690860232,
     "wof:name":"Southampton",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/91/85669391.geojson
+++ b/data/856/693/91/85669391.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u0993\u09af\u09bc\u09be\u09b0\u0989\u0987\u0995 \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
+    "name:bul_x_preferred":[
+        "\u0423\u043e\u0440\u0438\u043a"
+    ],
     "name:ceb_x_preferred":[
         "Warwick Parish"
     ],
@@ -61,6 +64,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0ab5\u0acb\u0ab0\u0ab5\u0abf\u0a95 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d5\u05d5\u05e8\u05d5\u05d5\u05d9\u05e7"
     ],
     "name:hin_x_preferred":[
         "\u0935\u093e\u0930\u0935\u093f\u0915 \u092a\u0948\u0930\u093f\u0936"
@@ -97,6 +103,9 @@
     ],
     "name:nob_x_preferred":[
         "Warwick prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Warwick Parish"
     ],
     "name:nor_x_preferred":[
         "Warwick prestegjeld"
@@ -274,7 +283,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501347,
+    "wof:lastmodified":1690860231,
     "wof:name":"Warwick",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/890/429/559/890429559.geojson
+++ b/data/890/429/559/890429559.geojson
@@ -22,6 +22,15 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u062c\u0648\u0631\u062c"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646\u062a \u062c\u0648\u0631\u062c"
+    ],
+    "name:azb_x_preferred":[
+        "\u0627\u06cc\u0633\u062a. \u062c\u0648\u0631\u062c'\u0633"
+    ],
+    "name:bel_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0440\u0434\u0436"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u099c\u09b0\u09cd\u099c"
     ],
@@ -80,8 +89,14 @@
     "name:hun_x_preferred":[
         "Saint George"
     ],
+    "name:hye_x_preferred":[
+        "\u054d\u0578\u0582\u0580\u0562 \u054b\u0578\u0580\u057b"
+    ],
     "name:ind_x_preferred":[
         "St. George"
+    ],
+    "name:ind_x_variant":[
+        "Saint George"
     ],
     "name:ita_x_preferred":[
         "Saint George"
@@ -204,7 +219,7 @@
         }
     ],
     "wof:id":890429559,
-    "wof:lastmodified":1636501348,
+    "wof:lastmodified":1690860232,
     "wof:name":"Saint George",
     "wof:parent_id":85669373,
     "wof:placetype":"locality",

--- a/data/890/442/097/890442097.geojson
+++ b/data/890/442/097/890442097.geojson
@@ -25,6 +25,15 @@
     "name:ara_x_preferred":[
         "\u0647\u0627\u0645\u064a\u0644\u062a\u0648\u0646"
     ],
+    "name:arg_x_preferred":[
+        "Hamilton"
+    ],
+    "name:ary_x_preferred":[
+        "\u0647\u0627\u0645\u064a\u0644\u0637\u0648\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0647\u0627\u0645\u064a\u0644\u062a\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
         "Hamilton"
     ],
@@ -33,6 +42,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0430\u043c\u0456\u043b\u044c\u0442\u0430\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0413\u0430\u043c\u0456\u043b\u044c\u0442\u0430\u043d"
     ],
     "name:ben_x_preferred":[
         "\u09b9\u09cd\u09af\u09be\u09ae\u09bf\u09b2\u09cd\u099f\u09a8"
@@ -53,6 +65,9 @@
         "Hamilton"
     ],
     "name:ces_x_preferred":[
+        "Hamilton"
+    ],
+    "name:cym_x_preferred":[
         "Hamilton"
     ],
     "name:dan_x_preferred":[
@@ -121,6 +136,9 @@
     "name:ind_x_preferred":[
         "Hamilton"
     ],
+    "name:isl_x_preferred":[
+        "Hamilton"
+    ],
     "name:ita_x_preferred":[
         "Hamilton"
     ],
@@ -141,6 +159,9 @@
     ],
     "name:lav_x_preferred":[
         "Hamiltona"
+    ],
+    "name:lij_x_preferred":[
+        "Hamilton"
     ],
     "name:lit_x_preferred":[
         "Hamiltonas"
@@ -202,11 +223,13 @@
     "name:spa_x_preferred":[
         "Hamilton"
     ],
-    "name:spa_x_variant":[],
     "name:srp_x_preferred":[
         "\u0425\u0430\u043c\u0438\u043b\u0442\u043e\u043d"
     ],
     "name:swe_x_preferred":[
+        "Hamilton"
+    ],
+    "name:szl_x_preferred":[
         "Hamilton"
     ],
     "name:tam_x_preferred":[
@@ -214,6 +237,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c39\u0c3e\u0c2e\u0c3f\u0c32\u0c4d\u0c1f\u0c28\u0c4d"
+    ],
+    "name:tgk_x_preferred":[
+        "\u04b2\u043e\u043c\u0438\u043b\u0442\u0443\u043d"
     ],
     "name:tha_x_preferred":[
         "\u0e41\u0e2e\u0e21\u0e34\u0e25\u0e15\u0e31\u0e19"
@@ -232,6 +258,9 @@
     ],
     "name:war_x_preferred":[
         "Hamilton"
+    ],
+    "name:wuu_x_preferred":[
+        "\u54c8\u5bc6\u5c14\u987f"
     ],
     "name:yor_x_preferred":[
         "Hamilton"
@@ -374,7 +403,7 @@
         }
     ],
     "wof:id":890442097,
-    "wof:lastmodified":1636501348,
+    "wof:lastmodified":1690860233,
     "wof:name":"Hamilton",
     "wof:parent_id":85669363,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.