### PR TITLE
bm concordances, placetype local, and more

### DIFF
--- a/data/856/693/45/85669345.geojson
+++ b/data/856/693/45/85669345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000066,
-    "geom:area_square_m":689211.419558,
+    "geom:area_square_m":689180.337136,
     "geom:bbox":"-64.794525,32.289549,-64.784425,32.29734",
     "geom:latitude":32.293413,
     "geom:longitude":-64.7893,
@@ -245,13 +245,15 @@
         "gn:id":3573195,
         "gp:id":20069918,
         "hasc:id":"BM.HC",
+        "iso:code":"BM-HA",
         "iso:id":"BM-HA",
         "qs_pg:id":49363,
         "wd:id":"Q289876",
         "wk:page":"Hamilton Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"39a8bf79a1ded8421b7cf6b730dd17c5",
+    "wof:geomhash":"204312fb2e70824046acd55583c6b78d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -268,7 +270,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860230,
+    "wof:lastmodified":1695884883,
     "wof:name":"City of Hamilton",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/51/85669351.geojson
+++ b/data/856/693/51/85669351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000075,
-    "geom:area_square_m":778379.349811,
+    "geom:area_square_m":778382.618565,
     "geom:bbox":"-64.681024,32.369778,-64.668491,32.380969",
     "geom:latitude":32.375305,
     "geom:longitude":-64.674648,
@@ -198,11 +198,13 @@
         "gn:id":3573062,
         "gp:id":20069917,
         "hasc:id":"BM.SG",
+        "iso:code":"BM-SG",
         "iso:id":"BM-SG",
         "qs_pg:id":888179
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"d7e05315e6d4311f3b2299c789fc71ba",
+    "wof:geomhash":"3528823c9e185b8580e02130265e194f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -217,7 +219,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501347,
+    "wof:lastmodified":1695884883,
     "wof:name":"City of Saint George",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/693/55/85669355.geojson
+++ b/data/856/693/55/85669355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00064,
-    "geom:area_square_m":6685918.065389,
+    "geom:area_square_m":6685833.942617,
     "geom:bbox":"-64.780141,32.286175,-64.73793,32.316527",
     "geom:latitude":32.301936,
     "geom:longitude":-64.759352,
@@ -243,13 +243,15 @@
         "gn:id":3573251,
         "gp:id":2344751,
         "hasc:id":"BM.DE",
+        "iso:code":"BM-DEV",
         "iso:id":"BM-DEV",
         "qs_pg:id":1310773,
         "wd:id":"Q1207018",
         "wk:page":"Devonshire Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"e07ef3dbe133df78a54dc690fd0c29ed",
+    "wof:geomhash":"f0eb2f62e0020f1f01416470bb316070",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -266,7 +268,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860231,
+    "wof:lastmodified":1695884883,
     "wof:name":"Devonshire",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/59/85669359.geojson
+++ b/data/856/693/59/85669359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000612,
-    "geom:area_square_m":6391262.325003,
+    "geom:area_square_m":6391275.231034,
     "geom:bbox":"-64.742671,32.316959,-64.694916,32.352512",
     "geom:latitude":32.338298,
     "geom:longitude":-64.719831,
@@ -249,10 +249,12 @@
     "wof:concordances":{
         "fips:code":"BD02",
         "hasc:id":"BM.HA",
+        "iso:code":"BM-HAM",
         "iso:id":"BM-HAM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"4f727efd44610617b02d38938ce03aa8",
+    "wof:geomhash":"35c501e5177748f1fb70d2ec274cdef0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -269,7 +271,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501346,
+    "wof:lastmodified":1695884883,
     "wof:name":"Hamilton",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/63/85669363.geojson
+++ b/data/856/693/63/85669363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00056,
-    "geom:area_square_m":5852309.096153,
+    "geom:area_square_m":5852268.799743,
     "geom:bbox":"-64.811191,32.265283,-64.760819,32.296369",
     "geom:latitude":32.281142,
     "geom:longitude":-64.780229,
@@ -254,13 +254,15 @@
         "gn:id":3573103,
         "gp:id":2344754,
         "hasc:id":"BM.PA",
+        "iso:code":"BM-PAG",
         "iso:id":"BM-PAG",
         "qs_pg:id":318285,
         "wd:id":"Q2046204",
         "wk:page":"Paget Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"24c20ffbc5240ae17746c3955fd91131",
+    "wof:geomhash":"8d9e6fed9824f58f67b32900c4c556a8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860231,
+    "wof:lastmodified":1695884883,
     "wof:name":"Paget",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/67/85669367.geojson
+++ b/data/856/693/67/85669367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000371,
-    "geom:area_square_m":3877646.785834,
+    "geom:area_square_m":3877479.32469,
     "geom:bbox":"-64.813967,32.289549,-64.779021,32.307559",
     "geom:latitude":32.299484,
     "geom:longitude":-64.796236,
@@ -247,13 +247,15 @@
         "gn:id":3573095,
         "gp:id":2344753,
         "hasc:id":"BM.PE",
+        "iso:code":"BM-PEM",
         "iso:id":"BM-PEM",
         "qs_pg:id":318283,
         "wd:id":"Q1756036",
         "wk:page":"Pembroke Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"9f1c706b37880a81c094acc7960eadd4",
+    "wof:geomhash":"f61d74a9c1e361fa11dce19517cdbb8f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -270,7 +272,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860230,
+    "wof:lastmodified":1695884883,
     "wof:name":"Pembroke",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/73/85669373.geojson
+++ b/data/856/693/73/85669373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001392,
-    "geom:area_square_m":14540976.619618,
+    "geom:area_square_m":14540726.467489,
     "geom:bbox":"-64.72202,32.326369,-64.647631,32.388658",
     "geom:latitude":32.362859,
     "geom:longitude":-64.683162,
@@ -242,13 +242,15 @@
         "gn:id":3573057,
         "gp:id":2344755,
         "hasc:id":"BM.SC",
+        "iso:code":"BM-SGE",
         "iso:id":"BM-SGE",
         "qs_pg:id":423582,
         "wd:id":"Q1521745",
         "wk:page":"St. George's Parish, Bermuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"4d8fc7c3f01a3bc3978bbba5a726cdc5",
+    "wof:geomhash":"c419480ffc117c44bd0cdd5d690c0468",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -265,7 +267,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860230,
+    "wof:lastmodified":1695884883,
     "wof:name":"Saint George's",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/77/85669377.geojson
+++ b/data/856/693/77/85669377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000687,
-    "geom:area_square_m":7184439.005949,
+    "geom:area_square_m":7184382.246023,
     "geom:bbox":"-64.885994,32.265932,-64.834137,32.329739",
     "geom:latitude":32.290608,
     "geom:longitude":-64.866158,
@@ -244,13 +244,15 @@
         "gn:id":3573050,
         "gp:id":2344756,
         "hasc:id":"BM.SA",
+        "iso:code":"BM-SAN",
         "iso:id":"BM-SAN",
         "qs_pg:id":423583,
         "wd:id":"Q121782",
         "wk:page":"Sandys Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"9437ab19abac169c509de070e1ccfdc7",
+    "wof:geomhash":"8e5accd38168fe4814aa5c1ccf0f1514",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -267,7 +269,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860231,
+    "wof:lastmodified":1695884883,
     "wof:name":"Sandys",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/81/85669381.geojson
+++ b/data/856/693/81/85669381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000461,
-    "geom:area_square_m":4817058.144865,
+    "geom:area_square_m":4817034.444104,
     "geom:bbox":"-64.748161,32.302142,-64.707289,32.32947",
     "geom:latitude":32.316007,
     "geom:longitude":-64.728923,
@@ -241,13 +241,15 @@
         "gn:id":3573031,
         "gp:id":2344757,
         "hasc:id":"BM.SM",
+        "iso:code":"BM-SMI",
         "iso:id":"BM-SMI",
         "qs_pg:id":423584,
         "wd:id":"Q1735847",
         "wk:page":"Smith's Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"7bd2712fbaeab243c3965a05ebd46e14",
+    "wof:geomhash":"d7a4eb3e2c4c1c73e0188a76a8b7a107",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -264,7 +266,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860230,
+    "wof:lastmodified":1695884883,
     "wof:name":"Smith's",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/85/85669385.geojson
+++ b/data/856/693/85/85669385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000586,
-    "geom:area_square_m":6123580.529125,
+    "geom:area_square_m":6123543.050277,
     "geom:bbox":"-64.88016,32.248077,-64.815152,32.269008",
     "geom:latitude":32.256191,
     "geom:longitude":-64.849047,
@@ -241,13 +241,15 @@
         "gn:id":3573026,
         "gp:id":2344758,
         "hasc:id":"BM.SO",
+        "iso:code":"BM-SOU",
         "iso:id":"BM-SOU",
         "qs_pg:id":423593,
         "wd:id":"Q1323054",
         "wk:page":"Southampton Parish, Bermuda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"b9128836b93cb7a655816f9f7e75926e",
+    "wof:geomhash":"72fd680eee193ba255c377b60c552dfb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -264,7 +266,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860232,
+    "wof:lastmodified":1695884883,
     "wof:name":"Southampton",
     "wof:parent_id":85632731,
     "wof:placetype":"region",

--- a/data/856/693/91/85669391.geojson
+++ b/data/856/693/91/85669391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000649,
-    "geom:area_square_m":6785650.214266,
+    "geom:area_square_m":6785559.10485,
     "geom:bbox":"-64.832895,32.254281,-64.788306,32.289936",
     "geom:latitude":32.270348,
     "geom:longitude":-64.810758,
@@ -260,13 +260,15 @@
         "gn:id":3572972,
         "gp:id":2344759,
         "hasc:id":"BM.WA",
+        "iso:code":"BM-WAR",
         "iso:id":"BM-WAR",
         "qs_pg:id":423594,
         "wd:id":"Q1468860",
         "wk:page":"Warwick Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BM",
-    "wof:geomhash":"cea23a22dfc4937be41c71b0877fc759",
+    "wof:geomhash":"19ec0ca03805c15fec0d0f569c50072e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -283,7 +285,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690860231,
+    "wof:lastmodified":1695884883,
     "wof:name":"Warwick",
     "wof:parent_id":85632731,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.